### PR TITLE
README structure and focus refinement

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,17 +1,14 @@
 # tmux-portal
 
-A tmux plugin that streamlines session switching, new window creation, and command execution in a single workflow.
+A tmux plugin designed to manage AI agent workflows in dedicated sessions and quickly switch between them and your regular development environment.
 
-- Use case:
-  - Manage AI agent sessions in dedicated tmux sessions for focused work
+It streamlines session switching, new window creation, command execution, and status line customization into a single workflow.
 
 ## Features
 
-- **Session Switcher** - Quickly jump between tmux sessions
-- **Current session excluded from switch candidates** - Only shows other sessions when switching
-- **Session Auto-select** - No menu when there's only one option
-- **Custom Status Styles** - Specify status line colors for visual differentiation
-- **Command Integration** - Launch commands in new windows within specific sessions
+- **Session Switcher** - Quickly select and switch from sessions other than the current one (auto-selects if only one candidate exists)
+- **Command Integration** - Launch a command in a new window immediately upon switching sessions
+- **Custom Status Styles** - Visually identify sessions by specifying status line colors
 
 ## Installation
 
@@ -41,76 +38,35 @@ Reload tmux: `tmux source-file ~/.tmux.conf`
 
 ## Usage
 
-| Option | Description |
-|--------|-------------|
-| `-s, --session <name>` | Session name (creates if missing) |
-| `-c, --command <cmd>` | Command to run in new window |
-| `--status-style <style>` | tmux status bar style (e.g., `fg=black,bg=yellow`) |
-| `-h, --help` | Show help message |
-
-### Switch between a dedicated AI agent session and regular sessions
+### Basic Usage
+Display the session switcher and move to the selected session.
 
 ```bash
+tmux-portal
+```
+
+Displays an interactive menu of all sessions except your current one. Select a session by its number.
+
+#### Keybinding Example
+Add the following to your `.tmux.conf` for quick access:
+
+```tmux
+bind-key C-p run-shell "tmux-portal"
+```
+
+### Switching to a Dedicated AI Agent Session
+Create and switch to a session dedicated to an AI agent (e.g., Claude) and execute a command.
+
+```bash
+# Create/switch to "claude" session and run the "claude" command
 tmux-portal -s claude -c claude --status-style "fg=black,bg=orange"
 
-# Return to regular session
+# Return to a regular session (select from the switcher)
 tmux-portal
 ```
 
-### Basic Session Switching
-
-```bash
-# Show session switcher and jump to selected session
-tmux-portal
-```
-
-Displays an interactive menu of all sessions except your current one. Select with numbers.
-
-### Creating/Switching to Named Sessions
-
-```bash
-# Switch to (or create) a specific session
-tmux-portal --session my-project
-tmux-portal -s my-project
-```
-
-If the session doesn't exist, tmux-portal creates it before switching.
-
-### Running Commands in Sessions
-
-```bash
-# Launch claude in a session after selecting from menu
-tmux-portal --command claude
-
-# Launch claude in a specific session
-tmux-portal -s claude -c claude
-```
-
-Creates a new window in the target session and runs the command.
-
-### Visual Differentiation with Status Styles
-
-```bash
-# Color-code your Claude session with yellow status bar
-tmux-portal -s claude --status-style "fg=black,bg=yellow"
-
-# Different color for Codex session
-tmux-portal -s codex --status-style "fg=white,bg=blue"
-```
-
-Helps identify which AI agent you're working with at a glance.
-
-## Example Workflow
-
-```bash
-# Set up color-coded sessions for different AI agents
-tmux-portal -s claude -c claude --status-style "fg=black,bg=yellow"
-tmux-portal -s codex -c codex --status-style "fg=white,bg=blue"
-tmux-portal -s cursor -c cursor-agent --status-style "fg=black,bg=green"
-
-# Later, quickly switch between them
-tmux-portal  # Shows: codex, cursor (excludes current session)
-```
+## Options
+(New section - to be added in another issue)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # tmux-portal
 
-tmuxのセッション切り替えを効率化するプラグインです。セッション切り替え、新規ウィンドウ作成、指定したコマンドを実行まで一括で行う。
+AIエージェントとの作業を専用のtmuxセッションで管理し、通常の開発セッションと素早く切り替えるためのプラグインです。
 
-- ユースケース:
-  - AIエージェントとのセッションを専用のtmuxセッションに切り出して集中管理する
+セッションの切り替え、新規ウィンドウの作成、コマンド実行、ステータスラインのカスタマイズまで一括で行えます。
 
 ## Features
 
-- **セッションスイッチャー** - tmuxセッション間を素早く移動
-- **現在のセッションはスイッチ候補から除外** - 切り替え時は他のセッションのみ表示
-- **セッション自動選択** - 選択肢が1つだけの場合はメニューを表示せず自動選択
+- **セッションスイッチャー** - 現在のセッション以外から素早く選択・切り替え（候補が1つなら自動選択）
+- **コマンド統合** - セッション切り替えと同時に新規ウィンドウでコマンドを実行
 - **カスタムステータススタイル** - ステータスラインの色を指定して視覚的に識別
-- **コマンド統合** - 特定のセッション内に新規ウィンドウを作成してコマンドを実行
 
 ## Installation
 
@@ -41,76 +38,35 @@ tmuxを再読み込み: `tmux source-file ~/.tmux.conf`
 
 ## Usage
 
-| Option | Description |
-|--------|-------------|
-| `-s, --session <name>` | セッション名（存在しない場合は作成） |
-| `-c, --command <cmd>` | 新規ウィンドウで実行するコマンド |
-| `--status-style <style>` | tmuxステータスバースタイル（例: `fg=black,bg=yellow`） |
-| `-h, --help` | ヘルプメッセージを表示 |
-
-### AIエージェント専用のセッションと相互に切り替える
+### 基本的な使い方
+セッションスイッチャーを表示して、選択したセッションに移動します。
 
 ```bash
-tmux-portal -s claude -c claude --status-style "fg=black,bg=orange"
-
-# 通常セッションに戻る
-tmux-portal
-```
-
-### 基本的なセッション切り替え
-
-```bash
-# セッションスイッチャーを表示して選択したセッションに移動
 tmux-portal
 ```
 
 現在のセッション以外のすべてのセッションを対話的なメニューで表示します。数字で選択してください。
 
-### 名前付きセッションの作成/切り替え
+#### キーバインド例
+`.tmux.conf` に以下のように設定することで、素早くアクセスできます。
 
-```bash
-# 特定のセッションに切り替え（存在しない場合は作成）
-tmux-portal --session my-project
-tmux-portal -s my-project
+```tmux
+bind-key C-p run-shell "tmux-portal"
 ```
 
-セッションが存在しない場合、tmux-portalは切り替える前に作成します。
-
-### セッション内でのコマンド実行
-
-```bash
-# メニューからセッションを選択してclaudeを起動
-tmux-portal --command claude
-
-# 特定のセッションでclaudeを起動
-tmux-portal -s claude -c claude
-```
-
-対象セッション内に新規ウィンドウを作成してコマンドを実行します。
-
-### ステータススタイルによる視覚的な識別
+### AIエージェント専用セッションとの切り替え
+AIエージェント（例：Claude）専用のセッションを作成し、コマンドを実行します。
 
 ```bash
-# Claudeセッションを黄色のステータスバーで色分け
-tmux-portal -s claude --status-style "fg=black,bg=yellow"
+# Claudeセッションを作成/切り替えして、claudeコマンドを実行
+tmux-portal -s claude -c claude --status-style "fg=black,bg=orange"
 
-# Codexセッションには別の色を設定
-tmux-portal -s codex --status-style "fg=white,bg=blue"
+# 通常セッションに戻る（スイッチャーから選択）
+tmux-portal
 ```
 
-どのAIエージェントを使用しているか一目で識別できます。
-
-## Example Workflow
-
-```bash
-# 異なるAIエージェント用に色分けされたセッションを設定
-tmux-portal -s claude -c claude --status-style "fg=black,bg=yellow"
-tmux-portal -s codex -c codex --status-style "fg=white,bg=blue"
-tmux-portal -s cursor -c cursor-agent --status-style "fg=black,bg=green"
-
-# その後、素早く切り替え
-tmux-portal  # 表示内容: codex, cursor（現在のセッションは除外）
-```
+## Options
+(新規セクション - 別イシューで追加)
 
 ## Requirements
 


### PR DESCRIPTION
Improved the overall structure of both Japanese and English README files. The documentation now highlights the primary purpose of managing AI agent sessions, simplifies the feature set description, and streamlines the usage guide by removing redundant information and adding a practical keybinding example. parity between the two languages is maintained.

Fixes #6

---
*PR created automatically by Jules for task [15552823831180384690](https://jules.google.com/task/15552823831180384690) started by @zeero*